### PR TITLE
exclude migrations from Metrics/MethodLength cop

### DIFF
--- a/.rails-style.yml
+++ b/.rails-style.yml
@@ -1,0 +1,3 @@
+Metrics/MethodLength:
+  Exclude:
+    - 'db/migrate/*'

--- a/.ruby-style.yml
+++ b/.ruby-style.yml
@@ -19,6 +19,8 @@
 #
 # @see https://github.com/bbatsov/rubocop/blob/master/config/default.yml
 
+inherit_from: .rails-style.yml
+
 AllCops:
   TargetRubyVersion: 2.2
 


### PR DESCRIPTION
migrations can reasonably have very long methods when, for example, you're creating multiple tables in one .

see https://github.com/FundingCircle/alpaca/pull/857#discussion-diff-75837193 for context